### PR TITLE
Removing the hostname to the job commit.

### DIFF
--- a/src/scripts/pbs_status.py
+++ b/src/scripts/pbs_status.py
@@ -285,7 +285,7 @@ def get_qstat_location():
     _qstat_location_cache = location
     return location
 
-job_id_re = re.compile("\s*Job Id: ([0-9]+[\.\w\-]+)")
+job_id_re = re.compile("\s*Job Id: ([0-9]+)[\.\w\-]+")
 exec_host_re = re.compile("\s*exec_host = ([\w\-\/.]+)")
 status_re = re.compile("\s*job_state = ([QRECH])")
 exit_status_re = re.compile("\s*exit_status = (-?[0-9]+)")


### PR DESCRIPTION
pbs_submit.sh was changed for slurm support to only look at the job id numbers, not at the hostname (slurm output is weird). pbs_status.py would look for the entire jobid, with hostname, but the gahp would only give the number, therefore pbs_status.py could not find the job.
