### PR TITLE
Change os.rename to shutil.move to atomically move the cache_file

### DIFF
--- a/src/scripts/pbs_status.py
+++ b/src/scripts/pbs_status.py
@@ -39,6 +39,7 @@ import random
 import struct
 import signal
 import tempfile
+import shutil
 
 cache_timeout = 60
 
@@ -322,7 +323,7 @@ def fill_cache(cache_location):
     except:
         os.unlink(filename)
         raise
-    os.rename(filename, cache_location)
+    shutil.move(filename, cache_location)
     global launchtime
     launchtime = time.time()
 

--- a/src/scripts/pbs_status.py
+++ b/src/scripts/pbs_status.py
@@ -312,7 +312,7 @@ def fill_cache(cache_location):
     log("Starting query to fill cache.")
     results = qstat()
     log("Finished query to fill cache.")
-    (fd, filename) = tempfile.mkstemp()
+    (fd, filename) = tempfile.mkstemp(dir='/var/tmp')
     try:
         for key, val in results.items():
             key = key.split(".")[0]

--- a/src/scripts/pbs_status.py
+++ b/src/scripts/pbs_status.py
@@ -39,7 +39,6 @@ import random
 import struct
 import signal
 import tempfile
-import shutil
 
 cache_timeout = 60
 
@@ -323,7 +322,7 @@ def fill_cache(cache_location):
     except:
         os.unlink(filename)
         raise
-    shutil.move(filename, cache_location)
+    os.rename(filename, cache_location)
     global launchtime
     launchtime = time.time()
 


### PR DESCRIPTION
If the cache_directory (/var/tmp) is on a different filesystem
than the file created with tempfile.mkstemp, the os.rename
will fail.  shutil.move catches and corrects for this error
for us.
