### PR TITLE
pbs_status.py fails to find qstat in a non-standard location if it isn't

### DIFF
--- a/src/scripts/pbs_status.py
+++ b/src/scripts/pbs_status.py
@@ -249,7 +249,8 @@ def get_qstat_location():
     global _qstat_location_cache
     if _qstat_location_cache != None:
         return _qstat_location_cache
-    if os.path.exists("blah_load_config.sh") and os.access("blah_load_config.sh", os.R_OK):
+    load_config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'blah_load_config.sh')
+    if os.path.exists(load_config_path) and os.access(load_config_path, os.R_OK):
         cmd = 'source blah_load_config.sh && echo "$pbs_binpath/qstat"'
     else:
         cmd = 'which qstat'


### PR DESCRIPTION
run in the directory that has blah_load_config.sh (SOFTWARE-1594). This issue was first noticed with HTCondor CE's setup at Vanderbilt.
