### PR TITLE
Add lsf_status.patch to fix memory allocation errors (SOFTWARE-1589)

### DIFF
--- a/src/scripts/lsf_status.sh
+++ b/src/scripts/lsf_status.sh
@@ -229,7 +229,7 @@ END {
 		touch $datefile;chmod 600 $datefile
 
 		if [ $? -ne 0 ]; then
-   			echo 'Error creating temporary file'
+   			echo '1ERROR: Could not create temporary file'
    			datefile=""
 			echo "1ERROR: Job not found"
 			break


### PR DESCRIPTION
When the error handler hits this line, it chokes and segfaults. First noticed with SLAC's HTCondor CE setup.
