### PR TITLE
Fix bug when sacct doesn't reply.

### DIFF
--- a/src/scripts/pbs_status.py
+++ b/src/scripts/pbs_status.py
@@ -321,7 +321,8 @@ def get_finished_job_stats(jobid):
         try:
             reader = csv.DictReader(child_stdout, delimiter="|")
         except Exception, e:
-            log("Unable to read in CSV output from sacct: %s" str(e))
+            log("Unable to read in CSV output from sacct: %s" % str(e))
+            return return_dict
             
         # Slurm can return more than 1 row, for some odd reason.
         # so sum up relevant values


### PR DESCRIPTION
When sacct doesn't reply, either because the DB is busy or some
other bottleneck, the pbs_status.py finish function should gracefully
return nothing.
