### PR TITLE
Sw2168 lsf suspended

### DIFF
--- a/src/scripts/lsf_status.sh
+++ b/src/scripts/lsf_status.sh
@@ -319,15 +319,15 @@ $0 ~ rex_finished {
 }
 
 $0 ~ rex_uhold {
-	jobstatus = 5
+	jobstatus = 7
 }
 
 $0 ~ rex_phold {
-	jobstatus = 5
+	jobstatus = 1
 }
 
 $0 ~ rex_shold {
-	jobstatus = 5
+	jobstatus = 7
 }
 
 END {


### PR DESCRIPTION
https://jira.opensciencegrid.org/browse/SOFTWARE-2199

I decided to leave this line alone https://github.com/osg-bosco/BLAH/blob/v1_18_bosco/src/scripts/lsf_status.sh#L168 since I believe it is meant to handle the PSUSP or 'Pending' state and could cause havoc if we change it. What I did change should be sufficient for Wei.
