### PR TITLE
Add ability to wrap the payload job.

### DIFF
--- a/src/scripts/blah_common_submit_functions.sh
+++ b/src/scripts/blah_common_submit_functions.sh
@@ -664,7 +664,7 @@ function bls_start_job_wrapper ()
       echo "\$new_home/`basename $bls_opt_the_command` $bls_arguments &"
       echo "fi" 
   else
-      echo "\$NODE_COUNT=$bls_opt_mpinodes"
+      echo "export NODE_COUNT=$bls_opt_mpinodes"
       echo "$blah_job_wrapper $bls_opt_the_command $bls_arguments &" 
   fi
   

--- a/src/scripts/blah_common_submit_functions.sh
+++ b/src/scripts/blah_common_submit_functions.sh
@@ -664,7 +664,7 @@ function bls_start_job_wrapper ()
       echo "\$new_home/`basename $bls_opt_the_command` $bls_arguments &"
       echo "fi" 
   else
-      echo "\$NODE_COUNT=$$bls_opt_mpinodes"
+      echo "\$NODE_COUNT=$bls_opt_mpinodes"
       echo "$blah_job_wrapper $bls_opt_the_command $bls_arguments &" 
   fi
   

--- a/src/scripts/blah_common_submit_functions.sh
+++ b/src/scripts/blah_common_submit_functions.sh
@@ -664,6 +664,7 @@ function bls_start_job_wrapper ()
       echo "\$new_home/`basename $bls_opt_the_command` $bls_arguments &"
       echo "fi" 
   else
+      echo "\$NODE_COUNT=$$bls_opt_mpinodes"
       echo "$blah_job_wrapper $bls_opt_the_command $bls_arguments &" 
   fi
   

--- a/src/scripts/blah_common_submit_functions.sh
+++ b/src/scripts/blah_common_submit_functions.sh
@@ -664,7 +664,7 @@ function bls_start_job_wrapper ()
       echo "\$new_home/`basename $bls_opt_the_command` $bls_arguments &"
       echo "fi" 
   else
-      echo "$bls_opt_the_command $bls_arguments &" 
+      echo "$blah_job_wrapper $bls_opt_the_command $bls_arguments &" 
   fi
   
   echo "job_pid=\$!" 


### PR DESCRIPTION
Provide hook for wrapping the payload job with an admin-controlled script on the worker node.

This will help us run in places like NERSC where we need to run a separate script to launch parallel versions of the payload.
