### PR TITLE
Support dynamic assignment of env variables

### DIFF
--- a/src/mapped_exec.c
+++ b/src/mapped_exec.c
@@ -158,10 +158,8 @@ merciful_kill(pid_t pid, exec_cmd_t *cmd)
 char *
 escape_wordexp_special_chars(char *in)
 {
-  char *special="|&;<>(){}";
+  char *special="|$&;<>(){}";
   int inside_double_quotes;
-  int inside_single_quotes;
-  int inside_command_subst;
 
   int special_count;
 
@@ -185,7 +183,6 @@ escape_wordexp_special_chars(char *in)
 
   inside_double_quotes = FALSE;
   inside_single_quotes = FALSE;
-  inside_command_subst = FALSE;
 
   for (wcur=ret,prev='\000',cur=in; *cur != '\000'; cur++)
    {
@@ -198,7 +195,7 @@ escape_wordexp_special_chars(char *in)
           inside_single_quotes = FALSE;
          }
        }
-      else if (!inside_double_quotes && !inside_command_subst)
+      else if (!inside_double_quotes)
        {
         inside_single_quotes = TRUE;
        }
@@ -212,41 +209,19 @@ escape_wordexp_special_chars(char *in)
           inside_double_quotes = FALSE;
          }
        }
-      else if (!inside_single_quotes && !inside_command_subst)
+      else if (!inside_single_quotes)
        {
         inside_double_quotes = TRUE;
-       }
-     }
-    if (*cur == '(')
-     {
-      if (!inside_single_quotes && !inside_double_quotes &&
-          prev == '$')
-       {
-        inside_command_subst = TRUE;
        }
      }
 
     if (strchr(special, *cur) != NULL)
      {
-      if (!inside_single_quotes && !inside_double_quotes &&
-          !inside_command_subst)
+      if (!inside_single_quotes && !inside_double_quotes)
        {
         /* Escape special character */
         *wcur = '\\';
         wcur++;
-       }
-     }
-
-    /* This check must follow the special character escape check */
-    /* as ')' is one of the special characters */
-    if (*cur == ')')
-     {
-      if (inside_command_subst)
-       {
-        if (prev != '\\')
-         {
-          inside_command_subst = FALSE;
-         }
        }
      }
 

--- a/src/mapped_exec.c
+++ b/src/mapped_exec.c
@@ -182,24 +182,9 @@ escape_wordexp_special_chars(char *in)
 
 
   inside_double_quotes = FALSE;
-  inside_single_quotes = FALSE;
 
   for (wcur=ret,prev='\000',cur=in; *cur != '\000'; cur++)
    {
-    if (*cur == '\'')
-     {
-      if (inside_single_quotes)
-       {
-        if (prev != '\\')
-         {
-          inside_single_quotes = FALSE;
-         }
-       }
-      else if (!inside_double_quotes)
-       {
-        inside_single_quotes = TRUE;
-       }
-     }
     if (*cur == '"')
      {
       if (inside_double_quotes)
@@ -209,15 +194,11 @@ escape_wordexp_special_chars(char *in)
           inside_double_quotes = FALSE;
          }
        }
-      else if (!inside_single_quotes)
-       {
-        inside_double_quotes = TRUE;
-       }
      }
 
     if (strchr(special, *cur) != NULL)
      {
-      if (!inside_single_quotes && !inside_double_quotes)
+      if (!inside_double_quotes)
        {
         /* Escape special character */
         *wcur = '\\';

--- a/src/scripts/blah_common_submit_functions.sh
+++ b/src/scripts/blah_common_submit_functions.sh
@@ -601,9 +601,9 @@ function bls_start_job_wrapper ()
   if [ "x$bls_opt_environment" != "x" ] ; then
           echo ""
           echo "# Setting the environment:"
-  	eval "env_array=($bls_opt_environment)"
+          env_array=($bls_opt_environment)
           for  env_var in "${env_array[@]}"; do
-                   echo export \"$env_var\"
+              echo export \"$env_var\"
           done
   else
           if [ "x$bls_opt_envir" != "x" ] ; then


### PR DESCRIPTION
https://jira.opensciencegrid.org/browse/SOFTWARE-2221

> Bockjoo Kim would like better support for assigning `OSG_WN_TMP=$FOO` so that the `OSG_WN_TMP` would be set to an env variable `$FOO` that's set on a worker node. The blahp mangles the environmental variables that are fed to it by HTCondor-CE in at least one [place](https://github.com/osg-bosco/BLAH/blob/v1_18_bosco/src/scripts/blah_common_submit_functions.sh#L604).

I also changed the behavior to escape ALL parens (I think this is the right behavior, not sure if there are any exceptions we should consider) and single quotes (HTCondor-CE calls the blahp with vars surrounded by single quotes). 

I made a scratch build with these changes and successfully submitted jobs with bash variables defined in `osg-job-environment.conf`.
