### PR TITLE
Escape special characters when creating the temporary home directory

### DIFF
--- a/src/scripts/blah_common_submit_functions.sh
+++ b/src/scripts/blah_common_submit_functions.sh
@@ -620,6 +620,11 @@ function bls_start_job_wrapper ()
   else
     run_dir="home_$bls_tmp_name"
   fi
+
+  # Replace special characters, because lcg-cp (calling globus_url_copy) cannot
+  # handle them in the path. (In particular, '#', from the Condor job ID)
+  run_dir=${run_dir//[^[:alnum:]-_.]/_}
+
   if [ -n "$blah_wn_temporary_home_dir" ] ; then
     echo "new_home=${blah_wn_temporary_home_dir}/$run_dir"
   else


### PR DESCRIPTION
lcg-cp (calling globus_url_copy) cannot handle '#' and other special characters in the path.
