### PR TITLE
Support dynamic assignment of env variables (SOFTWARE-2221)

### DIFF
--- a/src/scripts/blah_common_submit_functions.sh
+++ b/src/scripts/blah_common_submit_functions.sh
@@ -613,6 +613,12 @@ function bls_start_job_wrapper ()
           fi
   fi
   
+  JOB_ENV="/var/lib/osg/osg-job-environment.conf"
+  LOCAL_JOB_ENV="/var/lib/osg/osg-local-job-environment.conf"
+  for fname in $JOB_ENV $LOCAL_JOB_ENV; do
+    test -r $fname && echo "`grep -G \"^[^# ]\" $fname`"
+  done
+
   echo "old_home=\`pwd\`"
   # Set the temporary home (including cd'ing into it)
   if [ "x$bls_opt_run_dir" != "x" ] ; then


### PR DESCRIPTION
This patch reads all the variable setting and export statements in the `osg-job*-environment.conf` files and throws them into the blahp submit scripts. The most important part is that it doesn't evaluate any shell variables so the following in the configuration file:

```
OSG_WN_TMP="$FOO"
OSG_DATA=$BAR
export OSG_WN_TMP
export OSG_DATA
```

Will be added to the submit scripts, verbatim. I've tested this with a CE and a PBS backend to see the expected behavior.
