### PR TITLE
Print sbatch errors to stderr for handling by HTCondor's gridmanager

### DIFF
--- a/src/scripts/slurm_submit.sh
+++ b/src/scripts/slurm_submit.sh
@@ -84,6 +84,7 @@ retcode=$?
 
 if [ "$retcode" != "0" ] ; then
 	rm -f $bls_tmp_file
+	echo "Error from sbatch: $jobID" >&2
 	exit 1
 fi
 


### PR DESCRIPTION
This is the same as [pbs_submit.sh](https://github.com/osg-bosco/BLAH/blob/v1_18_bosco/src/scripts/pbs_submit.sh#L235). Without this change, held messages just read 'Attempts to submit failed:'.
