### PR TITLE
Fix bad spacing on request memory if statement

### DIFF
--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -245,7 +245,7 @@ then
   echo -e $xtra_args >> $submit_file
 fi
 
-if [ "x$req_mem" != "x"]
+if [ "x$req_mem" != "x" ]
 then
   echo "request_memory = $req_mem" >> $submit_file
 fi


### PR DESCRIPTION
Curiously, this is fixed in Condor's blahp but not ours.
