### PR TITLE
Change from -N to -c for multi-cores per node

### DIFF
--- a/src/scripts/slurm_submit.sh
+++ b/src/scripts/slurm_submit.sh
@@ -64,8 +64,8 @@ bls_set_up_local_and_extra_args
 
 # Simple support for multi-cpu attributes
 if [[ $bls_opt_mpinodes -gt 1 ]] ; then
-  echo "#SBATCH -N 1" >> $bls_tmp_file
-  echo "#SBATCH -n $bls_opt_mpinodes" >> $bls_tmp_file
+  echo "#SBATCH --nodes=1" >> $bls_tmp_file
+  echo "#SBATCH --ntasks=$bls_opt_mpinodes" >> $bls_tmp_file
 fi
 
 

--- a/src/scripts/slurm_submit.sh
+++ b/src/scripts/slurm_submit.sh
@@ -64,7 +64,8 @@ bls_set_up_local_and_extra_args
 
 # Simple support for multi-cpu attributes
 if [[ $bls_opt_mpinodes -gt 1 ]] ; then
-  echo "#SBATCH -c $bls_opt_mpinodes" >> $bls_tmp_file
+  echo "#SBATCH -N 1" >> $bls_tmp_file
+  echo "#SBATCH -n $bls_opt_mpinodes" >> $bls_tmp_file
 fi
 
 

--- a/src/scripts/slurm_submit.sh
+++ b/src/scripts/slurm_submit.sh
@@ -64,7 +64,7 @@ bls_set_up_local_and_extra_args
 
 # Simple support for multi-cpu attributes
 if [[ $bls_opt_mpinodes -gt 1 ]] ; then
-  echo "#SBATCH -N $bls_opt_mpinodes" >> $bls_tmp_file
+  echo "#SBATCH -c $bls_opt_mpinodes" >> $bls_tmp_file
 fi
 
 


### PR DESCRIPTION
The -N option is for the number of nodes.  -c is for the number of cores per task.
Since we care about the number of cores on a single node, -c is more appropriate.
