### PR TITLE
Fix broken PBS/slurm job queries when no jobid was specified

### DIFF
--- a/src/scripts/pbs_status.py
+++ b/src/scripts/pbs_status.py
@@ -232,13 +232,13 @@ def qstat(jobid=""):
 
     starttime = time.time()
     log("Starting qstat.")
-    if re.search(r'PBSPro', qstat_version):
-        command = (qstat_bin, '-f', jobid) # -1 conflicts with -f in PBS Pro
-    else:
-        command = (qstat_bin, '-f', '-1', jobid)
+    command = (qstat_bin, '-f')
+    if not re.search(r'PBSPro', qstat_version):
+        command += ('-1',) # -1 conflicts with -f in PBS Pro
+    if jobid:
+        command += (jobid,)
     qstat_proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     qstat_out, _ = qstat_proc.communicate()
-
     result = parse_qstat(qstat_out)
     log("Finished qstat (time=%f)." % (time.time()-starttime))
 

--- a/src/scripts/slurm_status.py
+++ b/src/scripts/slurm_status.py
@@ -229,7 +229,9 @@ def call_scontrol(jobid=""):
 
     starttime = time.time()
     log("Starting scontrol.")
-    command = (scontrol, 'show', 'job', jobid)
+    command = (scontrol, 'show', 'job')
+    if jobid:
+        command += (jobid,)
     scontrol_proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     scontrol_out, _ = scontrol_proc.communicate()
 


### PR DESCRIPTION
When using subprocess.Popen, empty strings are respected as arguments
causing some versions of qstat (UFL's 4.2.9) to fail when job IDs were
not specified in the qstat call.

Fixed for Bockjoo here: https://ticket.opensciencegrid.org/31613
