### PR TITLE
Put all #SBATCH commands together

### DIFF
--- a/src/scripts/slurm_submit.sh
+++ b/src/scripts/slurm_submit.sh
@@ -63,14 +63,15 @@ then
   echo "#SBATCH --mem=${bls_opt_req_mem}" >> $bls_tmp_file
 fi
 
-bls_set_up_local_and_extra_args
-
 # Simple support for multi-cpu attributes
 if [[ $bls_opt_mpinodes -gt 1 ]] ; then
   echo "#SBATCH --nodes=1" >> $bls_tmp_file
   echo "#SBATCH --ntasks=$bls_opt_mpinodes" >> $bls_tmp_file
 fi
 
+# Do the local and extra args after all #SBATCH commands, otherwise slurm ignores anything
+# after a non-#SBATCH command
+bls_set_up_local_and_extra_args
 
 # Input and output sandbox setup.
 # Assume all filesystems are shared.


### PR DESCRIPTION
Slurm ignores #SBATCH commands that are after normal commands.
We allow the admins to include local attributes, which can also
include commands such as including modules...  All of which
has to be after the #SBATCH commands.