### PR TITLE
Fail gracefully when parsing unexpected sacct output (SOFTWARE-2604)

### DIFF
--- a/src/scripts/pbs_status.py
+++ b/src/scripts/pbs_status.py
@@ -517,10 +517,15 @@ job_status_re = re.compile(".*JobStatus=(\d+);.*")
 def main():
     initLog()
 
-    if len(sys.argv) != 2:
+    # Accept the optional -w argument, but ignore it
+    if len(sys.argv) == 2:
+        jobid_arg = sys.argv[1]
+    elif len(sys.argv) == 3 and sys.argv[1] == "-w":
+        jobid_arg = sys.argv[2]
+    else:
         print "1Usage: pbs_status.sh pbs/<date>/<jobid>"
         return 1
-    jobid = sys.argv[1].split("/")[-1].split(".")[0]
+    jobid = jobid_arg.split("/")[-1].split(".")[0]
     log("Checking cache for jobid %s" % jobid)
     cache_contents = None
     try:

--- a/src/scripts/pbs_status.py
+++ b/src/scripts/pbs_status.py
@@ -282,9 +282,8 @@ def which(program):
     return None
 
 def convert_cpu_to_seconds(cpu_string):
-    import re
-    h,m,s = re.split(':',cpu_string)
-    return int(h) * 3600 + int(m) * 60 + int(s)
+    hrs, mins, secs = re.split(':', cpu_string)
+    return int(hrs) * 3600 + int(mins) * 60 + int(secs)
 
 _cluster_type_cache = None
 def get_finished_job_stats(jobid):
@@ -330,24 +329,25 @@ def get_finished_job_stats(jobid):
         except Exception, e:
             log("Unable to read in CSV output from sacct: %s" % str(e))
             return return_dict
-            
+
+        sacct_parser = {'RemoteUserCpu': lambda orig, results: orig + \
+                        convert_cpu_to_seconds(results["AveCPU"]) * int(results["AllocCPUS"]),
+                        'ImageSize': lambda orig, results: orig + int(results["MaxRSS"].replace('K', '')),
+                        'ExitCode': lambda orig, results: int(results["ExitCode"].split(":")[0])}
         # Slurm can return more than 1 row, for some odd reason.
         # so sum up relevant values
         for row in reader:
-            if row["AveCPU"] is not "":
-                return_dict['RemoteUserCpu'] += convert_cpu_to_seconds(row["AveCPU"]) * int(row["AllocCPUS"])
-            if row["MaxRSS"] is not "":
-                # Remove the trailing 'K'
-                return_dict["ImageSize"] += int(row["MaxRSS"].replace('K', ''))
-            if row["ExitCode"] is not "":
-                return_dict["ExitCode"] = int(row["ExitCode"].split(":")[0])
-    
-    # PBS completion        
+            for attr, func in sacct_parser.items():
+                try:
+                    return_dict[attr] = func(return_dict[attr], row)
+                except (ValueError, KeyError), exc:
+                    log("Could not parse %s for Jobid %s: %s" % (attr, jobid, exc))
+
+    # PBS completion
     elif _cluster_type_cache == "pbs":
         pass
 
     return return_dict
-    
 
 _qstat_location_cache = None
 def get_qstat_location():

--- a/src/scripts/slurm_status.py
+++ b/src/scripts/slurm_status.py
@@ -476,10 +476,15 @@ job_status_re = re.compile(".*JobStatus=(\d+);.*")
 def main():
     initLog()
 
-    if len(sys.argv) != 2:
+    # Accept the optional -w argument, but ignore it
+    if len(sys.argv) == 2:
+        jobid_arg = sys.argv[1]
+    elif len(sys.argv) == 3 and sys.argv[1] == "-w":
+        jobid_arg = sys.argv[2]
+    else:
         print "1Usage: slurm_status.py slurm/<date>/<jobid>"
         return 1
-    jobid = sys.argv[1].split("/")[-1].split(".")[0]
+    jobid = jobid_arg.split("/")[-1].split(".")[0]
     log("Checking cache for jobid %s" % jobid)
     cache_contents = None
     try:


### PR DESCRIPTION
I tested this on a Fermicloud VM against a local slurm setup. My only concern is that the added `log()` statement may trigger too often:

```
02/21/17 12:56:58 18244 Could not parse RemoteUserCpu for Jobid 6: need more than 1 value to unpack
02/21/17 12:56:58 18244 Could not parse ImageSize for Jobid 6: invalid literal for int() with base 10: ''
```

Because the first row returned by our `sacct` command has undefined `AveCPU`, `AllocCPUS`, and `MaxRSS` fields. I've thought about handling those cases to prevent them from hitting the logs but I could see that making troubleshooting annoying in the future.

This also contains the change for #52.