### PR TITLE
Fix setting the number of CPUs per job

### DIFF
--- a/src/scripts/slurm_submit.sh
+++ b/src/scripts/slurm_submit.sh
@@ -66,6 +66,7 @@ fi
 # Simple support for multi-cpu attributes
 if [[ $bls_opt_mpinodes -gt 1 ]] ; then
   echo "#SBATCH --nodes=1" >> $bls_tmp_file
+  echo "#SBATCH --ntasks=1" >> $bls_tmp_file
   echo "#SBATCH --cpus-per-task=$bls_opt_mpinodes" >> $bls_tmp_file
 fi
 

--- a/src/scripts/slurm_submit.sh
+++ b/src/scripts/slurm_submit.sh
@@ -66,7 +66,7 @@ fi
 # Simple support for multi-cpu attributes
 if [[ $bls_opt_mpinodes -gt 1 ]] ; then
   echo "#SBATCH --nodes=1" >> $bls_tmp_file
-  echo "#SBATCH --ntasks=$bls_opt_mpinodes" >> $bls_tmp_file
+  echo "#SBATCH --cpus-per-task=$bls_opt_mpinodes" >> $bls_tmp_file
 fi
 
 # Do the local and extra args after all #SBATCH commands, otherwise slurm ignores anything


### PR DESCRIPTION
`ntasks` only specifies a maximum number of tasks to be given by the
slurm controller (default 1 task/node).

https://slurm.schedmd.com/sbatch.html
https://ticket.opensciencegrid.org/34033