### PR TITLE
Fix python loading of blah.config

### DIFF
--- a/src/scripts/blah.py
+++ b/src/scripts/blah.py
@@ -22,5 +22,8 @@ class BlahConfigParser(RawConfigParser, object):
         return super(BlahConfigParser, self).items(self.header)
 
     def get(self, option):
-        return super(BlahConfigParser, self).get(self.header, option)
+        # ConfigParser happily includes quotes in value strings, which we
+        # happily allow in /etc/blah.config. This causes failures when joining
+        # paths, for example.
+        return super(BlahConfigParser, self).get(self.header, option).strip('"\'')
 

--- a/src/scripts/pbs_status.py
+++ b/src/scripts/pbs_status.py
@@ -43,7 +43,7 @@ import tempfile
 import pickle
 import csv
 
-sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import blah
 
 cache_timeout = 60

--- a/src/scripts/pbs_status.py
+++ b/src/scripts/pbs_status.py
@@ -233,7 +233,7 @@ def qstat(jobid=""):
     starttime = time.time()
     log("Starting qstat.")
     command = (qstat_bin, '-f')
-    if os.environ.get('pbs_pro').lower() != 'yes':
+    if config.get('pbs_pro').lower() != 'yes':
         command += ('-1',) # -1 conflicts with -f in PBS Pro
     if jobid:
         command += (jobid,)
@@ -358,7 +358,7 @@ def get_qstat_location():
     if _qstat_location_cache != None:
         return _qstat_location_cache
     try:
-        cmd = os.path.join(os.environ['pbs_binpath'], 'qstat')
+        cmd = os.path.join(config.get('pbs_binpath'), 'qstat')
     except KeyError:
         cmd = 'which qstat'
     child_stdout = os.popen(cmd)
@@ -527,7 +527,8 @@ def main():
     jobid = jobid_arg.split("/")[-1].split(".")[0]
 
     config_dir = os.path.dirname(os.path.abspath(__file__))
-    blah.load_env(config_dir)
+    global config
+    config = blah.BlahConfigParser()
 
     log("Checking cache for jobid %s" % jobid)
     cache_contents = None

--- a/src/scripts/pbs_status.py
+++ b/src/scripts/pbs_status.py
@@ -357,15 +357,17 @@ def get_qstat_location():
     global _qstat_location_cache
     if _qstat_location_cache != None:
         return _qstat_location_cache
+
     try:
-        cmd = os.path.join(config.get('pbs_binpath'), 'qstat')
+        location = os.path.join(config.get('pbs_binpath'), 'qstat')
     except KeyError:
         cmd = 'which qstat'
-    child_stdout = os.popen(cmd)
-    output = child_stdout.read()
-    location = output.split("\n")[0].strip()
-    if child_stdout.close():
-        raise Exception("Unable to determine qstat location: %s" % output)
+        child_stdout = os.popen(cmd)
+        output = child_stdout.read()
+        location = output.split("\n")[0].strip()
+        if child_stdout.close():
+            raise Exception("Unable to determine qstat location: %s" % output)
+
     _qstat_location_cache = location
     return location
 

--- a/src/scripts/slurm_status.py
+++ b/src/scripts/slurm_status.py
@@ -43,7 +43,7 @@ import tempfile
 import pickle
 import csv
 
-sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import blah
 
 cache_timeout = 60

--- a/src/scripts/slurm_status.py
+++ b/src/scripts/slurm_status.py
@@ -336,14 +336,15 @@ def get_slurm_location(program):
     if _slurm_location_cache != None:
         return os.path.join(_slurm_location_cache, program)
     try:
-        cmd = os.path.join(config.get('slurm_binpath'), program)
+        location = os.path.join(config.get('slurm_binpath'), program)
     except KeyError:
         cmd = 'which %s' % program
-    child_stdout = os.popen(cmd)
-    output = child_stdout.read()
-    location = output.split("\n")[0].strip()
-    if child_stdout.close():
-        raise Exception("Unable to determine scontrol location: %s" % output)
+        child_stdout = os.popen(cmd)
+        output = child_stdout.read()
+        location = output.split("\n")[0].strip()
+        if child_stdout.close():
+            raise Exception("Unable to determine scontrol location: %s" % output)
+
     _slurm_location_cache = os.path.dirname(location)
     return location
 

--- a/src/scripts/slurm_status.py
+++ b/src/scripts/slurm_status.py
@@ -336,7 +336,7 @@ def get_slurm_location(program):
     if _slurm_location_cache != None:
         return os.path.join(_slurm_location_cache, program)
     try:
-        cmd = os.path.join(os.environ['slurm_binpath'], program)
+        cmd = os.path.join(config.get('slurm_binpath'), program)
     except KeyError:
         cmd = 'which %s' % program
     child_stdout = os.popen(cmd)


### PR DESCRIPTION
- Use `ConfigParser` instead of janky shell commands that don't even work in the first place 
- Ensure that we get the absolute *status.py path, just to be safe