### PR TITLE
Fix bug that broke shell parsing of *_binpath

### DIFF
--- a/config/blah.config.template
+++ b/config/blah.config.template
@@ -80,7 +80,7 @@ blah_require_proxy_on_submit=
 
 #Path where PBS executables are located 
 # NOTE: this path is computed many times; I worry about the overhead here.  -BB, 12-13-2012
-pbs_binpath=`which qsub 2>/dev/null|sed 's|/[^/]*$||'`
+pbs_binpath=/usr/bin
 
 #Path where the PBS logs are located ($pbs_spoolpath/server_logs)
 #pbs_spoolpath=
@@ -105,7 +105,7 @@ pbs_pro=no
 ##LSF common variables
 
 #Path where LSF executables are located 
-lsf_binpath=`which bsub 2>/dev/null|sed 's|/[^/]*$||'`
+lsf_binpath=/usr/bin
 
 #Path where the LSF conf file is located ($lsf_confpath/lsf.conf)
 lsf_confpath=
@@ -285,7 +285,7 @@ tracejob_max_output=
 ##Condor
 
 #condor bin location
-condor_binpath=`which condor_submit 2>/dev/null|sed 's|/[^/]*$||'`
+condor_binpath=/usr/bin
 
 #path to condor_config
 #export CONDOR_CONFIG="/etc/condor/condor_config"

--- a/src/scripts/blah.py
+++ b/src/scripts/blah.py
@@ -27,3 +27,8 @@ class BlahConfigParser(RawConfigParser, object):
         # paths, for example.
         return super(BlahConfigParser, self).get(self.header, option).strip('"\'')
 
+    def set(self, option, value):
+        return super(BlahConfigParser, self).set(self.header, option, value)
+
+    def has_option(self, option):
+        return super(BlahConfigParser, self).has_option(self.header, option)


### PR DESCRIPTION
Because the blahp is insane and the defaults are shell commands. I tested `pbs_binpath` and `slurm_binpath` set to:

1. Default shell commands
2. Other paths
3. Empty string
4. Missing entirely

I tested this via `condor_ce_trace` (`pbs_submit.sh` breaks on 3 and 4) and by calling `pbs_status.py` and `slurm_status.py` directly.