### PR TITLE
Retry SLURM job submission

### DIFF
--- a/src/scripts/slurm_submit.sh
+++ b/src/scripts/slurm_submit.sh
@@ -85,8 +85,17 @@ bls_add_job_wrapper
 ###############################################################
 
 datenow=`date +%Y%m%d`
-jobID=`${slurm_binpath}/sbatch $bls_tmp_file` # actual submission
-retcode=$?
+retry=0
+MAX_RETRY=3
+until [ $retry -eq $MAX_RETRY ] ; do
+    jobID=$(${slurm_binpath}/sbatch $bls_tmp_file)
+    retcode=$?
+    if [ "$retcode" == "0" ] ; then
+        break
+    fi
+    retry=$[$retry+1]
+    sleep 10
+done
 
 if [ "$retcode" != "0" ] ; then
 	rm -f $bls_tmp_file


### PR DESCRIPTION
Under load, the SLURM scheduler is prone to barf on any client commands.
Retry the job submission if it fails.

This should be exposed as configurable values, instead of being hardcoded.