### PR TITLE
Fix parsing of time fields for slurm jobs

### DIFF
--- a/src/scripts/slurm_status.py
+++ b/src/scripts/slurm_status.py
@@ -281,8 +281,16 @@ def which(program):
     return None
 
 def convert_cpu_to_seconds(cpu_string):
-    hrs, mins, secs = re.split(':', cpu_string)
-    return int(hrs) * 3600 + int(mins) * 60 + int(secs)
+    # The time fields in sacct's output have this format:
+    #   [DD-[hh:]]mm:ss
+    # Convert that to just seconds.
+    elem = re.split('[-:]', cpu_string)
+    secs = int(elem[-1]) + int(elem[-2]) * 60
+    if len(elem) > 2:
+        secs += int(elem[-3]) * 3600
+    if len(elem) > 3:
+        secs += int(elem[-4]) * 86400
+    return secs
 
 def get_finished_job_stats(jobid):
     """


### PR DESCRIPTION
Time fields in the output of slurm's sacct have optional day and hour
fields. https://htcondor-wiki.cs.wisc.edu/index.cgi/tktview?tn=6380