### PR TITLE
Fix uncaught exception when config doesn't contain pbs_pro

### DIFF
--- a/src/scripts/pbs_status.py
+++ b/src/scripts/pbs_status.py
@@ -233,7 +233,7 @@ def qstat(jobid=""):
     starttime = time.time()
     log("Starting qstat.")
     command = (qstat_bin, '-f')
-    if config.get('pbs_pro').lower() != 'yes':
+    if config.has_option('pbs_pro') and config.get('pbs_pro').lower() != 'yes':
         command += ('-1',) # -1 conflicts with -f in PBS Pro
     if jobid:
         command += (jobid,)


### PR DESCRIPTION
https://ticket.opensciencegrid.org/34702

I could've sworn I tested this case. We really need some blahp unit tests.