### PR TITLE
Set default values in blah.config

### DIFF
--- a/src/scripts/blah.py
+++ b/src/scripts/blah.py
@@ -6,7 +6,7 @@ from io import StringIO
 
 class BlahConfigParser(RawConfigParser, object):
 
-    def __init__(self, path='/etc/blah.config'):
+    def __init__(self, path='/etc/blah.config', defaults=None):
         # RawConfigParser requires ini-style [section headers] but since
         # blah.config is also used as a shell script we need to fake one
         self.header = 'blahp'
@@ -14,7 +14,7 @@ class BlahConfigParser(RawConfigParser, object):
             config = f.read()
         vfile = StringIO(u'[%s]\n%s' % (self.header, config))
 
-        super(BlahConfigParser, self).__init__()
+        super(BlahConfigParser, self).__init__(defaults=defaults)
         # TODO: readfp() is replaced by read_file() in Python 3.2+
         self.readfp(vfile)
 

--- a/src/scripts/pbs_status.py
+++ b/src/scripts/pbs_status.py
@@ -233,7 +233,7 @@ def qstat(jobid=""):
     starttime = time.time()
     log("Starting qstat.")
     command = (qstat_bin, '-f')
-    if config.has_option('pbs_pro') and config.get('pbs_pro').lower() != 'yes':
+    if config.get('pbs_pro').lower() != 'yes':
         command += ('-1',) # -1 conflicts with -f in PBS Pro
     if jobid:
         command += (jobid,)
@@ -358,8 +358,6 @@ def get_qstat_location():
     if _qstat_location_cache != None:
         return _qstat_location_cache
 
-    if not (config.has_option('pbs_binpath') and config.get('pbs_binpath')):
-        config.set('pbs_binpath', '/usr/bin')
     cmd = 'echo "%s/%s"' % (config.get('pbs_binpath'), 'qstat')
 
     child_stdout = os.popen(cmd)
@@ -528,7 +526,8 @@ def main():
     jobid = jobid_arg.split("/")[-1].split(".")[0]
 
     global config
-    config = blah.BlahConfigParser()
+    config = blah.BlahConfigParser(defaults={'pbs_pro': 'no',
+                                             'pbs_binpath': '/usr/bin'})
 
     log("Checking cache for jobid %s" % jobid)
     cache_contents = None

--- a/src/scripts/slurm_status.py
+++ b/src/scripts/slurm_status.py
@@ -344,8 +344,6 @@ def get_slurm_location(program):
     if _slurm_location_cache != None:
         return os.path.join(_slurm_location_cache, program)
 
-    if not (config.has_option('slurm_binpath') and config.get('slurm_binpath')):
-        config.set('slurm_binpath', '/usr/bin')
     cmd = 'echo "%s/%s"' % (config.get('slurm_binpath'), 'scontrol')
 
     child_stdout = os.popen(cmd)
@@ -499,7 +497,7 @@ def main():
     jobid = jobid_arg.split("/")[-1].split(".")[0]
 
     global config
-    config = blah.BlahConfigParser()
+    config = blah.BlahConfigParser(defaults={'slurm_binpath': '/usr/bin'})
 
     log("Checking cache for jobid %s" % jobid)
     cache_contents = None


### PR DESCRIPTION
Realized as I got home that my last change will fail in the case of a non-PBS Pro site missing the config, i.e. the generated cmd would be missing the `-1` option. Explicitly setting the default value to 'no' in the ConfigParser object should give us what we want.