### PR TITLE
Fix Slurm/PBS memory parsing (SOFTWARE-2929)

### DIFF
--- a/src/scripts/pbs_status.py
+++ b/src/scripts/pbs_status.py
@@ -336,8 +336,20 @@ def get_finished_job_stats(jobid):
             if row["AveCPU"] is not "":
                 return_dict['RemoteUserCpu'] += convert_cpu_to_seconds(row["AveCPU"]) * int(row["AllocCPUS"])
             if row["MaxRSS"] is not "":
-                # Remove the trailing 'K'
-                return_dict["ImageSize"] += int(row["MaxRSS"].replace('K', ''))
+                # Remove the trailing [KMGTP] and scale the value appropriately
+                # Note: We assume that all values will have a suffix, and we
+                #   want the value in kilos.
+                value = row["MaxRSS"]
+                factor = 1
+                if value[-1] == 'M':
+                    factor = 1024
+                elif value[-1] == 'G':
+                    factor = 1024 * 1024
+                elif value[-1] == 'T':
+                    factor = 1024 * 1024 * 1024
+                elif value[-1] == 'P':
+                    factor = 1024 * 1024 * 1024 * 1024
+                return_dict["ImageSize"] += int(value.strip('KMGTP')) * factor
             if row["ExitCode"] is not "":
                 return_dict["ExitCode"] = int(row["ExitCode"].split(":")[0])
     

--- a/src/scripts/slurm_status.py
+++ b/src/scripts/slurm_status.py
@@ -325,8 +325,20 @@ def get_finished_job_stats(jobid):
         if row["AveCPU"] is not "":
             return_dict['RemoteUserCpu'] += convert_cpu_to_seconds(row["AveCPU"]) * int(row["AllocCPUS"])
         if row["MaxRSS"] is not "":
-            # Remove the trailing 'K'
-            return_dict["ImageSize"] += int(row["MaxRSS"].replace('K', ''))
+            # Remove the trailing [KMGTP] and scale the value appropriately
+            # Note: We assume that all values will have a suffix, and we
+            #   want the value in kilos.
+            value = row["MaxRSS"]
+            factor = 1
+            if value[-1] == 'M':
+                factor = 1024
+            elif value[-1] == 'G':
+                factor = 1024 * 1024
+            elif value[-1] == 'T':
+                factor = 1024 * 1024 * 1024
+            elif value[-1] == 'P':
+                factor = 1024 * 1024 * 1024 * 1024
+            return_dict["ImageSize"] += int(value.strip('KMGTP')) * factor
         if row["ExitCode"] is not "":
             return_dict["ExitCode"] = int(row["ExitCode"].split(":")[0])
 

--- a/src/scripts/slurm_status.py
+++ b/src/scripts/slurm_status.py
@@ -318,22 +318,20 @@ def get_finished_job_stats(jobid):
     except Exception, e:
         log("Unable to read in CSV output from sacct: %s" % str(e))
         return return_dict
-
-    sacct_parser = {'RemoteUserCpu': lambda orig, results: orig + \
-                    convert_cpu_to_seconds(results["AveCPU"]) * int(results["AllocCPUS"]),
-                    'ImageSize': lambda orig, results: orig + int(results["MaxRSS"].replace('K', '')),
-                    'ExitCode': lambda orig, results: int(results["ExitCode"].split(":")[0])}
+           
     # Slurm can return more than 1 row, for some odd reason.
     # so sum up relevant values
     for row in reader:
-        for attr, func in sacct_parser.items():
-            try:
-                return_dict[attr] = func(return_dict[attr], row)
-            except (ValueError, KeyError), exc:
-                log("Could not parse %s for Jobid %s: %s" % (attr, jobid, exc))
+        if row["AveCPU"] is not "":
+            return_dict['RemoteUserCpu'] += convert_cpu_to_seconds(row["AveCPU"]) * int(row["AllocCPUS"])
+        if row["MaxRSS"] is not "":
+            # Remove the trailing 'K'
+            return_dict["ImageSize"] += int(row["MaxRSS"].replace('K', ''))
+        if row["ExitCode"] is not "":
+            return_dict["ExitCode"] = int(row["ExitCode"].split(":")[0])
 
     return return_dict
-
+    
 
 _slurm_location_cache = None
 def get_slurm_location(program):

--- a/src/scripts/slurm_status.py
+++ b/src/scripts/slurm_status.py
@@ -323,25 +323,36 @@ def get_finished_job_stats(jobid):
     # so sum up relevant values
     for row in reader:
         if row["AveCPU"] is not "":
-            return_dict['RemoteUserCpu'] += convert_cpu_to_seconds(row["AveCPU"]) * int(row["AllocCPUS"])
+            try:
+                return_dict['RemoteUserCpu'] += convert_cpu_to_seconds(row["AveCPU"]) * int(row["AllocCPUS"])
+            except:
+                log("Failed to parse CPU usage for job id %s: %s, %s" % (jobid, row["AveCPU"], row["AllocCPUS"]))
+                raise                
         if row["MaxRSS"] is not "":
             # Remove the trailing [KMGTP] and scale the value appropriately
             # Note: We assume that all values will have a suffix, and we
             #   want the value in kilos.
-            value = row["MaxRSS"]
-            factor = 1
-            if value[-1] == 'M':
-                factor = 1024
-            elif value[-1] == 'G':
-                factor = 1024 * 1024
-            elif value[-1] == 'T':
-                factor = 1024 * 1024 * 1024
-            elif value[-1] == 'P':
-                factor = 1024 * 1024 * 1024 * 1024
-            return_dict["ImageSize"] += int(value.strip('KMGTP')) * factor
+            try:
+                value = row["MaxRSS"]
+                factor = 1
+                if value[-1] == 'M':
+                    factor = 1024
+                elif value[-1] == 'G':
+                    factor = 1024 * 1024
+                elif value[-1] == 'T':
+                    factor = 1024 * 1024 * 1024
+                elif value[-1] == 'P':
+                    factor = 1024 * 1024 * 1024 * 1024
+                    return_dict["ImageSize"] += int(value.strip('KMGTP')) * factor
+            except:
+                log("Failed to parse memory usage for job id %s: %s" % (jobid, row["MaxRSS"]))
+                raise
         if row["ExitCode"] is not "":
-            return_dict["ExitCode"] = int(row["ExitCode"].split(":")[0])
-
+            try:
+                return_dict["ExitCode"] = int(row["ExitCode"].split(":")[0])
+            except:
+                log("Failed to parse memory usage for job id %s: %s" % (jobid, row["MaxRSS"]))
+                raise
     return return_dict
     
 


### PR DESCRIPTION
I reverted a previous patch of ours that condor didn't have. One thing we lose with that reversion is graceful failures when we don't parse the values correctly, which may not be such a bad thing since the jobs would fail loudly rather than silently logging. 

Perhaps the correct thing to do would be to add `try` blocks to log the failures and then re-raise the exception so that failure is still obvious. Thoughts @djw8605 ?