### PR TITLE
Fix unicode string error (SOFTWARE-2953)

### DIFF
--- a/src/scripts/blah.py
+++ b/src/scripts/blah.py
@@ -1,8 +1,8 @@
 """Common functions for BLAH python scripts"""
 
-import os
 from ConfigParser import RawConfigParser
-from io import StringIO
+# TODO: io.StringIO is preferred in Python3 since it handles unicode-encoded files
+from StringIO import StringIO
 
 class BlahConfigParser(RawConfigParser, object):
 
@@ -12,7 +12,7 @@ class BlahConfigParser(RawConfigParser, object):
         self.header = 'blahp'
         with open(path) as f:
             config = f.read()
-        vfile = StringIO(u'[%s]\n%s' % (self.header, config))
+        vfile = StringIO('[%s]\n%s' % (self.header, config))
 
         super(BlahConfigParser, self).__init__(defaults=defaults)
         # TODO: readfp() is replaced by read_file() in Python 3.2+

--- a/src/scripts/pbs_status.py
+++ b/src/scripts/pbs_status.py
@@ -40,6 +40,7 @@ import struct
 import subprocess
 import signal
 import tempfile
+import traceback
 import pickle
 import csv
 
@@ -564,5 +565,6 @@ if __name__ == "__main__":
     except SystemExit:
         raise
     except Exception, e:
+        log(traceback.format_exc())
         print "1ERROR: %s" % str(e).replace("\n", "\\n")
         sys.exit(0)

--- a/src/scripts/slurm_status.py
+++ b/src/scripts/slurm_status.py
@@ -40,6 +40,7 @@ import struct
 import subprocess
 import signal
 import tempfile
+import traceback
 import pickle
 import csv
 
@@ -534,5 +535,6 @@ if __name__ == "__main__":
     except SystemExit:
         raise
     except Exception, e:
+        log(traceback.format_exc())
         print "1ERROR: %s" % str(e).replace("\n", "\\n")
         sys.exit(0)


### PR DESCRIPTION
Also log tracebacks to the `*_status.log` files so that these errors aren't as much of a beast to debug.