### PR TITLE
segfault in blahpd cmd_submit_job()

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1159,7 +1159,7 @@ cmd_submit_job(void *args)
 	else if ((proxyname) != NULL && (!disable_limited_proxy))
 	{
 		/* not in glexec mode: need to limit the proxy */
-		char *errmsg;
+		char *errmsg = NULL;
 		if((proxynameNew = limit_proxy(proxyname, NULL, &errmsg)) == NULL)
 		{
 			/* PUSH A FAILURE */


### PR DESCRIPTION
We've seen a few segfaults in the `free(errmsg)` call in `cmd_submit_job()` when running blahp-1.18.34.bosco-1.osg34.el6.x86_64.

```
#0  0x00007fb88718d495 in raise () from /lib64/libc.so.6
#1  0x00007fb88718ec75 in abort () from /lib64/libc.so.6
#2  0x00007fb8871cb3a7 in __libc_message () from /lib64/libc.so.6
#3  0x00007fb8871d0dee in malloc_printerr () from /lib64/libc.so.6
#4  0x00007fb8871d3c80 in _int_free () from /lib64/libc.so.6
#5  0x0000000000407a77 in cmd_submit_job (args=0x754170) at server.c:1169
#6  0x00007fb887c96aa1 in start_thread () from /lib64/libpthread.so.0
#7  0x00007fb887243bcd in clone () from /lib64/libc.so.6
```

It seems that `limit_proxy()` is not guaranteed to set `errmsg`. Initializing the variable to NULL should fix the issue.
