### PR TITLE
Check input files exist before submitting to SLURM

### DIFF
--- a/src/scripts/blah_common_submit_functions.sh
+++ b/src/scripts/blah_common_submit_functions.sh
@@ -130,6 +130,34 @@ function bls_fl_subst_and_accumulate ()
   done
 }
 
+function bls_fl_test_exists ()
+{
+#
+# Usage: bls_fl_test_exists container_name
+# Verfies all container_name "@@F_LOCAL" exists
+# First missing file is returned in $bls_fl_test_exists_result.
+#
+  local container_name
+
+  container_name=${1:?"Missing container name argument to bls_fl_subst_and_accumulate"}
+
+  local last_argument
+
+  eval "last_argument=\${bls_${container_name}_counter:=0}"
+
+  local ind
+  bls_fl_test_exists_result=
+  for (( ind=0 ; ind < $last_argument ; ind++ )) ; do
+      bls_fl_subst $container_name $ind "@@F_LOCAL"
+      if [ ! -z "$bls_fl_subst_result" -a ! -f "$bls_fl_subst_result" ] ; then
+          bls_fl_test_exists_result="${bls_fl_subst_result}"
+          return 1
+      fi
+  done
+  return 0
+}
+
+
 function bls_fl_subst_and_dump ()
 {
 #

--- a/src/scripts/slurm_submit.sh
+++ b/src/scripts/slurm_submit.sh
@@ -70,6 +70,14 @@ if [[ $bls_opt_mpinodes -gt 1 ]] ; then
   echo "#SBATCH --cpus-per-task=$bls_opt_mpinodes" >> $bls_tmp_file
 fi
 
+# Ensure local files actually exist before submitting job. This prevents
+# unnecessary churn on the scheduler if the files don't exist.  
+if ! bls_fl_test_exists inputsand ; then
+    echo "Input sandbox file doesn't exist: $bls_fl_test_exists_result" >&2
+    echo Error # for the sake of waiting fgets in blahpd
+    exit 1
+fi
+
 # Do the local and extra args after all #SBATCH commands, otherwise slurm ignores anything
 # after a non-#SBATCH command
 bls_set_up_local_and_extra_args

--- a/src/scripts/slurm_submit.sh
+++ b/src/scripts/slurm_submit.sh
@@ -70,6 +70,14 @@ if [[ $bls_opt_mpinodes -gt 1 ]] ; then
   echo "#SBATCH --cpus-per-task=$bls_opt_mpinodes" >> $bls_tmp_file
 fi
 
+# Verify the workdir exists before submitting the job. If a bogus workdir is
+# given, the job is hopeless
+if [[ ! -z "$bls_opt_workdir" && ! -d "$bls_opt_workdir" ]] ; then
+  echo "Error: Workdir doesn't exist" >&2
+  echo Error # for the sake of waiting fgets in blahpd
+  exit 1
+fi
+
 # Ensure local files actually exist before submitting job. This prevents
 # unnecessary churn on the scheduler if the files don't exist.  
 if ! bls_fl_test_exists inputsand ; then


### PR DESCRIPTION
For some reason, condor-ce and BLAH can get out of sync -- the net
result is that BLAH is told to submit jobs whose input files (and even
parent directories!) don't exist in condor's spol directory. These jobs
are doomed to fail and be later restarted, causing a lot of unnecessary
churn on the SLURM scheduler.

Before submitting jobs to SLURM, verify that the input files exist. If
they don't, error out early.