### PR TITLE
Save debug submit info before submission (SOFTWARE-2827)

### DIFF
--- a/src/scripts/blah_common_submit_functions.sh
+++ b/src/scripts/blah_common_submit_functions.sh
@@ -786,38 +786,39 @@ function bls_set_up_local_and_extra_args ()
   fi
 }
 
+function bls_save_submit () {
+    if [ -d "$blah_debug_save_submit_info" -a -n "$bls_tmp_name" ]; then
+        # Store files used for this job in a directory
+        bls_info_dir="$blah_debug_save_submit_info/$bls_tmp_name.debug"     
+        mkdir "$bls_info_dir"
+        if [ $? -eq 0 ]; then
+            # Best effort.
+            if [ -r "$bls_proxy_local_file" ]; then
+                cp "$bls_proxy_local_file" "$bls_info_dir/submit.proxy"
+            fi
+            if [ -r "$bls_opt_stdout" ]; then
+                ln "$bls_opt_stdout" "$bls_info_dir/job.stdout"
+                if [ $? -ne 0 ]; then
+                    # If we cannot hardlink, try a soft link.
+                    ln -s "$bls_opt_stdout" "$bls_info_dir/job.stdout"
+                fi
+            fi
+            if [ -r "$bls_opt_stderr" ]; then
+                ln "$bls_opt_stderr" "$bls_info_dir/job.stderr"
+                if [ $? -ne 0 ]; then
+                    # If we cannot hardlink, try a soft link.
+                    ln -s "$bls_opt_stderr" "$bls_info_dir/job.stderr"
+                fi
+            fi
+            if [ -r "$bls_tmp_file" ]; then
+                cp "$bls_tmp_file" "$bls_info_dir/submit.script"
+            fi
+        fi
+    fi    
+}
+
 function bls_wrap_up_submit ()
 {
-
-  if [ -d "$blah_debug_save_submit_info" -a -n "$bls_tmp_name" ]; then
-    # Store files used for this job in a directory
-    bls_info_dir="$blah_debug_save_submit_info/$bls_tmp_name.debug"     
-    mkdir "$bls_info_dir"
-    if [ $? -eq 0 ]; then
-      # Best effort.
-      if [ -r "$bls_proxy_local_file" ]; then
-        cp "$bls_proxy_local_file" "$bls_info_dir/submit.proxy"
-      fi
-      if [ -r "$bls_opt_stdout" ]; then
-        ln "$bls_opt_stdout" "$bls_info_dir/job.stdout"
-        if [ $? -ne 0 ]; then
-          # If we cannot hardlink, try a soft link.
-          ln -s "$bls_opt_stdout" "$bls_info_dir/job.stdout"
-        fi
-      fi
-      if [ -r "$bls_opt_stderr" ]; then
-        ln "$bls_opt_stderr" "$bls_info_dir/job.stderr"
-        if [ $? -ne 0 ]; then
-          # If we cannot hardlink, try a soft link.
-          ln -s "$bls_opt_stderr" "$bls_info_dir/job.stderr"
-        fi
-      fi
-      if [ -r "$bls_tmp_file" ]; then
-        cp "$bls_tmp_file" "$bls_info_dir/submit.script"
-      fi
-    fi
-  fi
-
   bls_fl_clear inputsand
   bls_fl_clear outputsand
   bls_fl_clear inputcopy

--- a/src/scripts/lsf_submit.sh
+++ b/src/scripts/lsf_submit.sh
@@ -161,6 +161,7 @@ echo "    cd \$CERN_STARTER_ORIGINAL_CWD" >> $bls_tmp_file
 echo "fi" >> $bls_tmp_file
 
 bls_add_job_wrapper
+bls_save_submit
 
 # Let the wrap script be at least 1 second older than logfile
 # for subsequent "find -newer" command to work

--- a/src/scripts/pbs_submit.sh
+++ b/src/scripts/pbs_submit.sh
@@ -214,6 +214,7 @@ fi
 echo "#PBS -m n"  >> $bls_tmp_file
 
 bls_add_job_wrapper
+bls_save_submit
 
 # Let the wrap script be at least 1 second older than logfile
 # for subsequent "find -newer" command to work

--- a/src/scripts/sge_submit.sh
+++ b/src/scripts/sge_submit.sh
@@ -94,6 +94,7 @@ bls_fl_subst_and_accumulate outputsand "@@F_REMOTE@`hostname -f`:@@F_LOCAL" "@@@
 echo "#$ -m n"  >> $bls_tmp_file
 
 bls_add_job_wrapper
+bls_save_submit
 
 ###############################################################
 # Submit the script

--- a/src/scripts/slurm_submit.sh
+++ b/src/scripts/slurm_submit.sh
@@ -78,7 +78,7 @@ bls_set_up_local_and_extra_args
 # Assume all filesystems are shared.
 
 bls_add_job_wrapper
-
+bls_save_submit
 
 ###############################################################
 # Submit the script


### PR DESCRIPTION
> Trey Dockendorf was debugging a new job route and needed to inspect the blahp-constructed torque submit files that are saved to `bl_*` dirs within the dir specified by `blah_debug_save_submit_info` in his blah.config (https://ticket.grid.iu.edu/34424). However, the blahp removes these dirs as part of its cleanup, making it particularly difficult. We should not cleanup the dir if `qsub` fails and `blah_debug_save_submit_info` is set.

Tested successfully with PBS. @edquist please take a quick look at this