### PR TITLE
Check workdir and input files before job submission (SOFTWARE-3154)

### DIFF
--- a/src/scripts/blah_common_submit_functions.sh
+++ b/src/scripts/blah_common_submit_functions.sh
@@ -768,8 +768,10 @@ function bls_finish_job_wrapper ()
   fi
 }
 
-function bls_test_working_dir ()
+function bls_test_input_files ()
 {
+  # Verify the workdir can be accessed before submitting the job. If a bogus workdir is
+  # given, the job is hopeless
   if [ "x$bls_opt_workdir" != "x" ]; then
       cd $bls_opt_workdir
   elif [ "x$blah_set_default_workdir_to_home" == "xyes" ]; then
@@ -782,13 +784,22 @@ function bls_test_working_dir ()
       rm -f $bls_tmp_file
       exit 1
   fi
+
+  # Ensure local files actually exist. When called before job submission, this prevents
+  # unnecessary churn on the scheduler if the files don't exist.
+  if ! bls_fl_test_exists inputsand ; then
+      echo "Input sandbox file doesn't exist: $bls_fl_test_exists_result" >&2
+      echo Error # for the sake of waiting fgets in blahpd
+      rm -rf $bls_tmp_file
+      exit 1
+  fi
 }
 
 function bls_add_job_wrapper ()
 {
+  bls_test_input_files
   bls_start_job_wrapper >> $bls_tmp_file
   bls_finish_job_wrapper >> $bls_tmp_file
-  bls_test_working_dir
 }
 
 function bls_set_up_local_and_extra_args ()

--- a/src/scripts/blah_common_submit_functions.sh
+++ b/src/scripts/blah_common_submit_functions.sh
@@ -790,7 +790,7 @@ function bls_test_input_files ()
   if ! bls_fl_test_exists inputsand ; then
       echo "Input sandbox file doesn't exist: $bls_fl_test_exists_result" >&2
       echo Error # for the sake of waiting fgets in blahpd
-      rm -rf $bls_tmp_file
+      rm -f "$bls_tmp_file"
       exit 1
   fi
 }

--- a/src/scripts/slurm_submit.sh
+++ b/src/scripts/slurm_submit.sh
@@ -70,22 +70,6 @@ if [[ $bls_opt_mpinodes -gt 1 ]] ; then
   echo "#SBATCH --cpus-per-task=$bls_opt_mpinodes" >> $bls_tmp_file
 fi
 
-# Verify the workdir exists before submitting the job. If a bogus workdir is
-# given, the job is hopeless
-if [[ ! -z "$bls_opt_workdir" && ! -d "$bls_opt_workdir" ]] ; then
-  echo "Error: Workdir doesn't exist" >&2
-  echo Error # for the sake of waiting fgets in blahpd
-  exit 1
-fi
-
-# Ensure local files actually exist before submitting job. This prevents
-# unnecessary churn on the scheduler if the files don't exist.  
-if ! bls_fl_test_exists inputsand ; then
-    echo "Input sandbox file doesn't exist: $bls_fl_test_exists_result" >&2
-    echo Error # for the sake of waiting fgets in blahpd
-    exit 1
-fi
-
 # Do the local and extra args after all #SBATCH commands, otherwise slurm ignores anything
 # after a non-#SBATCH command
 bls_set_up_local_and_extra_args


### PR DESCRIPTION
Use the pre-existing workdir test function, which catches permission
issues with the workdir as well as non-existence. Do this all before
we write out the job wrapper because why bother?

condor_submit doesn't benefit from this since it doesn't use
bls_add_job_wrapper (or any other common submit functions for that matter)

@edquist @PerilousApricot