### PR TITLE
tell wordexp not to do command substitution

### DIFF
--- a/src/blparser_master.c
+++ b/src/blparser_master.c
@@ -147,15 +147,15 @@ check_on_children_args(const struct blah_managed_child *children, const int coun
 				if((j = wordexp(children[i].exefile, &args, WRDE_NOCMD)))
 				{
 					fprintf(stderr,"wordexp: unable to parse the command line \"%s\" (error %d)\n", children[i].exefile, j);
-                			return;
-        			}
+					_exit(1);
+				}
 				/* Child process. Exec exe file. */
 				if (execv(args.we_wordv[0], args.we_wordv) < 0)
 				{
 					fprintf(stderr,"Cannot exec %s: %s\n",
 						children[i].exefile,
 						strerror(errno));
-					exit(1);
+					_exit(1);
 				}
 				/* Free the wordexp'd args */
  				wordfree(&args);

--- a/src/blparser_master.c
+++ b/src/blparser_master.c
@@ -144,7 +144,7 @@ check_on_children_args(const struct blah_managed_child *children, const int coun
 			fret = fork();
 			if (fret == 0)
 			{
-				if((j = wordexp(children[i].exefile, &args, 0)))
+				if((j = wordexp(children[i].exefile, &args, WRDE_NOCMD)))
 				{
 					fprintf(stderr,"wordexp: unable to parse the command line \"%s\" (error %d)\n", children[i].exefile, j);
                 			return;

--- a/src/mapped_exec.c
+++ b/src/mapped_exec.c
@@ -430,7 +430,7 @@ execute_cmd(exec_cmd_t *cmd)
 	}
 
 	/* Do the shell expansion */
-	if(wordexp_err = wordexp(command, &args, 0))
+	if(wordexp_err = wordexp(command, &args, WRDE_NOCMD))
 	{
 		fprintf(stderr,"wordexp: unable to parse the command line \"%s\" (error %d)\n", command, wordexp_err);
 		return(1);

--- a/src/mtsafe_popen.c
+++ b/src/mtsafe_popen.c
@@ -308,7 +308,7 @@ exe_getouterr(char *const command, char *const environment[], char **cmd_output,
 	envcopy[envcopy_size + i] = (char *)NULL;
 
 	/* Do the shell expansion */
-	if(i = wordexp(command, &args, 0))
+	if(i = wordexp(command, &args, WRDE_NOCMD))
 	{
 		fprintf(stderr,"wordexp: unable to parse the command line \"%s\" (error %d)\n", command, i);
 		return(1);


### PR DESCRIPTION
Also, fix the handling of wordexp errors