### PR TITLE
forward signals to payload job (SOFTWARE-3554)

### DIFF
--- a/src/scripts/blah_common_submit_functions.sh
+++ b/src/scripts/blah_common_submit_functions.sh
@@ -660,7 +660,7 @@ function bls_start_job_wrapper ()
     echo "new_home=\${old_home}/$run_dir"
   fi
 
-  echo "mkdir \$new_home"
+  echo 'mkdir "$new_home"'
   echo "trap 'wait \$job_pid; cd \$old_home; rm -rf \$new_home; exit 255' HUP INT QUIT TERM XCPU"
   echo "trap 'wait \$job_pid; cd \$old_home; rm -rf \$new_home' EXIT"
 

--- a/src/scripts/blah_common_submit_functions.sh
+++ b/src/scripts/blah_common_submit_functions.sh
@@ -661,8 +661,11 @@ function bls_start_job_wrapper ()
   fi
 
   echo 'mkdir "$new_home"'
-  echo "trap 'wait \$job_pid; cd \$old_home; rm -rf \$new_home; exit 255' HUP INT QUIT TERM XCPU"
-  echo "trap 'wait \$job_pid; cd \$old_home; rm -rf \$new_home' EXIT"
+  echo 'job_wait_cleanup () { wait "$job_pid"; cd "$old_home"; rm -rf "$new_home"; }'
+  echo 'on_signal () { kill -$1 "$job_pid"; job_wait_cleanup; exit 255; }'
+  echo 'trap_sigs () { for sig; do trap "on_signal $sig" $sig; done; }'
+  echo 'trap_sigs HUP INT QUIT TERM XCPU'
+  echo 'trap job_wait_cleanup EXIT'
 
   echo "# Copy into new home any shared input sandbox file"
   bls_fl_subst_and_dump inputcopy "cp \"@@F_LOCAL\" \"\$new_home/@@F_REMOTE\" &> /dev/null" 

--- a/src/scripts/blah_common_submit_functions.sh
+++ b/src/scripts/blah_common_submit_functions.sh
@@ -661,8 +661,8 @@ function bls_start_job_wrapper ()
   fi
 
   echo "mkdir \$new_home"
-  echo "trap 'wait \$job_pid; cd \$old_home; rm -rf \$new_home; exit 255' 1 2 3 15 24"
-  echo "trap 'wait \$job_pid; cd \$old_home; rm -rf \$new_home' 0"
+  echo "trap 'wait \$job_pid; cd \$old_home; rm -rf \$new_home; exit 255' HUP INT QUIT TERM XCPU"
+  echo "trap 'wait \$job_pid; cd \$old_home; rm -rf \$new_home' EXIT"
 
   echo "# Copy into new home any shared input sandbox file"
   bls_fl_subst_and_dump inputcopy "cp \"@@F_LOCAL\" \"\$new_home/@@F_REMOTE\" &> /dev/null" 


### PR DESCRIPTION
Resend each signal received to the payload job before waiting for it to complete, so it has a chance to clean up.

This supersedes #60, which only sent `SIGQUIT` to the payload jobs on signals.