### PR TITLE
Only query for completed jobs with a specific job ID (SOFTWARE-3675)

### DIFF
--- a/src/scripts/pbs_status.py
+++ b/src/scripts/pbs_status.py
@@ -234,12 +234,11 @@ def qstat(jobid=""):
     starttime = time.time()
     log("Starting qstat.")
     command = (qstat_bin, '-f')
-    if config.get('pbs_pro').lower() == 'yes':
-        command += ('-x',)  # also query for detailed output of finished jobs
-    else:
+    pbs_pro = config.get('pbs_pro').lower() == 'yes'
+    if not pbs_pro:
         command += ('-1',)  # -1 conflicts with -f in PBS Pro
     if jobid:
-        command += (jobid,)
+        command += ('-x', jobid) if pbs_pro else (jobid,)
     qstat_proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     qstat_out, _ = qstat_proc.communicate()
     result = parse_qstat(qstat_out)


### PR DESCRIPTION
We were accidentally asking for all completed jobs when updating the cache. @mmascher has a similar patch at WSU so let's wait until he verifies that it works this time ._.