### PR TITLE
escape existing quote characters first (SOFTWARE-3589)

### DIFF
--- a/src/scripts/condor_submit.sh
+++ b/src/scripts/condor_submit.sh
@@ -206,12 +206,12 @@ if [ "x$environment" != "x" ] ; then
     eval "env_array=($environment)"
     dq='"'
     sq="'"
-    # map key=val -> key='val'
-    env_array=("${env_array[@]/=/=$sq}")
-    env_array=("${env_array[@]/%/$sq}")
     # escape single-quote and double-quote characters (by doubling them)
     env_array=("${env_array[@]//$sq/$sq$sq}")
     env_array=("${env_array[@]//$dq/$dq$dq}")
+    # map key=val -> key='val'
+    env_array=("${env_array[@]/=/=$sq}")
+    env_array=("${env_array[@]/%/$sq}")
     submit_file_environment="environment = \"${env_array[*]}\""
 else
     if [ "x$envir" != "x" ] ; then


### PR DESCRIPTION
that is, before adding surrounding quotes

This fixes an extra-quoting bug introduced in d42bd8049c5ff73c6e7298afb0052dec0bc7efa3